### PR TITLE
fix: refactor proxy configuration logic in getSystemProxy function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,7 @@ export async function getSystemProxy(): Promise<ProxyConfig | undefined> {
 
         const noProxy = proxySettings.ExceptionsList || [];
 
-        if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
-            return {
-                proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
-                noProxy
-            };
-        } else if (proxySettings.HTTPEnable && proxySettings.HTTPProxy && proxySettings.HTTPPort) {
+        if (proxySettings.HTTPEnable && proxySettings.HTTPProxy && proxySettings.HTTPPort) {
             return {
                 proxyUrl: `http://${proxySettings.HTTPProxy}:${proxySettings.HTTPPort}`,
                 noProxy
@@ -40,6 +35,11 @@ export async function getSystemProxy(): Promise<ProxyConfig | undefined> {
         } else if (proxySettings.SOCKSEnable && proxySettings.SOCKSProxy && proxySettings.SOCKSPort) {
             return {
                 proxyUrl: `socks://${proxySettings.SOCKSProxy}:${proxySettings.SOCKSPort}`,
+                noProxy
+            };
+        } else if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
+            return {
+                proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
                 noProxy
             };
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export async function getSystemProxy(): Promise<ProxyConfig | undefined> {
             };
         } else if (proxySettings.HTTPSEnable && proxySettings.HTTPSProxy && proxySettings.HTTPSPort) {
             return {
-                proxyUrl: `https://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
+                proxyUrl: `http://${proxySettings.HTTPSProxy}:${proxySettings.HTTPSPort}`,
                 noProxy
             };
         } else {


### PR DESCRIPTION
On macOS, the HTTPS proxy directly returns something like `https://127.0.0.1:xxx`. However, most proxy software uses `export https_proxy=http://127.0.0.1:6152`, which can lead to the following error.

```
Uncaught Exception:
Error: Client network socket disconnected before secure TLS connection was established
at TLSSocket.onConnectEnd (node:_tls_wrap:1730:19)
at TLSSocket.emit (node:events:531:35)
at endReadableNT (node:internal/streams/readable:1696:12)
at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

Therefore, it is recommended to return `http` instead of `https`. Additionally, the `https` protocol might be placed at the end, as `http/socks` proxies are much more common and see more usage than `https` proxies.